### PR TITLE
Support patternProperties and additionalProperties

### DIFF
--- a/test/webjure/json_schema/validator_test.clj
+++ b/test/webjure/json_schema/validator_test.clj
@@ -25,9 +25,11 @@
           (is (nil? (get-in e [:properties "phoneNumber"])))))
 
       (testing "additional properties are reported"
-        (is (= {:error          :additional-properties
-                :property-names #{"youDidntExpectMe" "orMe"}}
-               (validate s (p "address-and-phone-additional-properties.json"))))))))
+        (let [e (validate s (p "address-and-phone-additional-properties.json"))]
+          (is (= :properties (:error e)))
+          (is (= {"youDidntExpectMe" {:error :additional-property}
+                  "orMe" {:error :additional-property}}
+                 (:properties e))))))))
 
 (deftest validate-referenced-schema
   (testing "person schema that links to address and phone schema"


### PR DESCRIPTION
Also added:
- allow data to have keywordized property names
- support local refs (e.g. #/inline/ref)

Note that this is breaking for the API:
- the `:ref-resolver` function now receives two parameters
- the `:additional-properties` error is now inside the `:properties` error.

Let me know what you think, @tatut.
