### PR TITLE
Merge completely rewritten validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/resources/JSON-Schema-Test-Suite"]
+	path = test/resources/JSON-Schema-Test-Suite
+	url = git@github.com:json-schema-org/JSON-Schema-Test-Suite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/resources/JSON-Schema-Test-Suite"]
 	path = test/resources/JSON-Schema-Test-Suite
-	url = git@github.com:json-schema-org/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# json-schema tools
+# json-schema validator
 
-Currently contains only a very minimal JSON schema validator using cheshire to parse JSON.
+Currently contains a usable JSON schema validator using cheshire to parse JSON.
 Supportes linked schemas with $ref and allows user to specify
-how linked URIs are resolved.
+how linked URIs are loaded.
 
 [![Clojars Project](http://clojars.org/webjure/json-schema/latest-version.svg)](http://clojars.org/webjure/json-schema)
+
+## Status
+
+The project is tested against [JSON-Schema-Test-Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite)
+and passes most of the tests.
+
+The macro version has problems with huge schemas (like loading the meta schema) as the generated
+code is too large for a single function.
+
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject webjure/json-schema "0.6.1"
+(defproject webjure/json-schema "0.7"
   :description "Minimalistic JSON schema validator with $ref support."
   :url "https://github.com/tatut/json-schema"
   :license {:name "MIT License"
             :url  "http://www.opensource.org/licenses/mit-license.php"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.6.1"]
                  [clj-time "0.11.0"]]
   :source-paths ["src"]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "MIT License"
             :url  "http://www.opensource.org/licenses/mit-license.php"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cheshire "5.5.0"]
-                 [clj-time "0.10.0"]]
+                 [cheshire "5.6.1"]
+                 [clj-time "0.11.0"]]
   :source-paths ["src"]
   :test-paths ["test"])

--- a/src/webjure/json_schema/ref.clj
+++ b/src/webjure/json_schema/ref.clj
@@ -7,14 +7,21 @@
     (when (.canRead schema)
       (cheshire/parse-string (slurp schema)))))
 
+(def definition-pattern #"#/definitions/(.+)$")
+
+(defn definition [{definitions :definitions} ref]
+  (when-let [[_ definition-name] (re-find definition-pattern ref)]
+    (get definitions definition-name)))
+
 (defn resolve-schema [schema options]
   (if-let [ref (get schema "$ref")]
-    (let [resolver (or (:ref-resolver options)
-                       resolve-ref)
-          referenced-schema (resolver ref)]
-      (if-not referenced-schema
-        ;; Throw exception if schema can't be loaded
-        (throw (IllegalArgumentException.
-                (str "Unable to resolve referenced schema: " ref)))
-        referenced-schema))
+    (or (definition options ref)
+        (let [resolver (or (:ref-resolver options)
+                           resolve-ref)
+              referenced-schema (resolver ref)]
+          (if-not referenced-schema
+            ;; Throw exception if schema can't be loaded
+            (throw (IllegalArgumentException.
+                    (str "Unable to resolve referenced schema: " ref)))
+            referenced-schema)))
     schema))

--- a/src/webjure/json_schema/ref.clj
+++ b/src/webjure/json_schema/ref.clj
@@ -1,27 +1,71 @@
 (ns webjure.json-schema.ref
   (:require [cheshire.core :as cheshire]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (defn resolve-ref [uri]
-  (let [schema (io/file uri)]
-    (when (.canRead schema)
-      (cheshire/parse-string (slurp schema)))))
+  ;;(println "LOAD " uri)
+  (cheshire/parse-string (slurp uri)))
 
-(def definition-pattern #"#/definitions/(.+)$")
+(def pointer-pattern #"^#/.*")
+(defn pointer? [ref]
+  (re-matches pointer-pattern ref))
 
-(defn definition [{definitions :definitions} ref]
-  (when-let [[_ definition-name] (re-find definition-pattern ref)]
-    (get definitions definition-name)))
+(defn- unescape [c]
+  (-> c
+      (str/replace #"~1" "/")
+      (str/replace #"~0" "~")
+      java.net.URLDecoder/decode))
+
+(defn dereference-pointer [root-schema ref]
+  (let [components  (-> ref
+                        (subs 2 (count ref))
+                        (str/split #"/"))
+        key-path (mapv (fn [c]
+                         (let [c (unescape c)]
+                           (if (re-matches #"\d+" c)
+                             (Long/parseLong c)
+                             c)))
+                       components)]
+    ;;(println "REF: " ref " => key path: " (pr-str key-path) "    root-schema: " root-schema)
+    (get-in root-schema key-path)))
+
+
+(defn- ref? [schema]
+  (contains? schema "$ref"))
 
 (defn resolve-schema [schema options]
-  (if-let [ref (get schema "$ref")]
-    (or (definition options ref)
+  (loop [schema schema
+         root-schema (:root-schema options)]
+    (let [ref (get schema "$ref")]
+      ;;(println "RESOLVE-SCHEMA, ref: " ref ", schema: " schema ", root: " root-schema)
+      (cond
+
+        ;; No reference, return as is
+        (nil? ref)
+        (do #_(println " => " schema) schema)
+
+        ;; Reference to whole document
+        (= ref "#")
+        (do #_(println " => " root-schema) root-schema)
+
+        ;; Pointer, dereference it
+        (pointer? ref)
+        (recur (dereference-pointer root-schema ref) root-schema)
+
+        ;; URI, try to load it
+        :default
         (let [resolver (or (:ref-resolver options)
                            resolve-ref)
               referenced-schema (resolver ref)]
-          (if-not referenced-schema
-            ;; Throw exception if schema can't be loaded
-            (throw (IllegalArgumentException.
-                    (str "Unable to resolve referenced schema: " ref)))
-            referenced-schema)))
-    schema))
+              (if-not referenced-schema
+                ;; Throw exception if schema can't be loaded
+                (throw (IllegalArgumentException.
+                        (str "Unable to resolve referenced schema: " ref)))
+                (recur referenced-schema referenced-schema)))))))
+
+(defn root-schema [{root :root-schema :as options} schema]
+  (if root
+    options
+    (assoc options
+           :root-schema (resolve-schema schema  options))))

--- a/src/webjure/json_schema/ref.clj
+++ b/src/webjure/json_schema/ref.clj
@@ -1,0 +1,20 @@
+(ns webjure.json-schema.ref
+  (:require [cheshire.core :as cheshire]
+            [clojure.java.io :as io]))
+
+(defn resolve-ref [uri]
+  (let [schema (io/file uri)]
+    (when (.canRead schema)
+      (cheshire/parse-string (slurp schema)))))
+
+(defn resolve-schema [schema options]
+  (if-let [ref (get schema "$ref")]
+    (let [resolver (or (:ref-resolver options)
+                       resolve-ref)
+          referenced-schema (resolver ref)]
+      (if-not referenced-schema
+        ;; Throw exception if schema can't be loaded
+        (throw (IllegalArgumentException.
+                (str "Unable to resolve referenced schema: " ref)))
+        referenced-schema))
+    schema))

--- a/src/webjure/json_schema/validator.clj
+++ b/src/webjure/json_schema/validator.clj
@@ -442,11 +442,13 @@
 
   :lax-date-time-format?  when set to true, allow more variation in date format,
                           normally only strict RFC3339 dates are valid"
-  [schema data options]
-  (let [options (-> options
-                    (ref/root-schema schema)
-                    (assoc :ref-resolver (or (:ref-resolver options)
-                                             (memoize ref/resolve-ref))))
-        schema (resolve-schema schema options)
-        definitions (get schema "definitions")]
-    (some #(% schema data options) validations)))
+  ([schema data]
+   (validate schema data {}))
+  ([schema data options]
+   (let [options (-> options
+                     (ref/root-schema schema)
+                     (assoc :ref-resolver (or (:ref-resolver options)
+                                              (memoize ref/resolve-ref))))
+         schema (resolve-schema schema options)
+         definitions (get schema "definitions")]
+     (some #(% schema data options) validations))))

--- a/src/webjure/json_schema/validator/format.clj
+++ b/src/webjure/json_schema/validator/format.clj
@@ -23,9 +23,8 @@
   (try
     (time-format/parse rfc3339-formatter (str d))
     nil
-    (catch Exception e
-      {:error :wrong-format :expected :date-time :data d
-       :parse-exception e})))
+    (catch Exception _
+      {:error :wrong-format :expected :date-time :data d})))
 
 (defn validate-hostname [d]
   (if (re-matches hostname-pattern (str d))

--- a/src/webjure/json_schema/validator/format.clj
+++ b/src/webjure/json_schema/validator/format.clj
@@ -1,5 +1,6 @@
 (ns webjure.json-schema.validator.format
-  (:require [clj-time.format :as time-format]))
+  (:require [clj-time.format :as time-format]
+            [clj-time.coerce :as time-coerce]))
 
 (def rfc3339-formatter (time-format/formatters :date-time))
 
@@ -25,6 +26,10 @@
     nil
     (catch Exception _
       {:error :wrong-format :expected :date-time :data d})))
+
+(defn validate-lax-date-time [d]
+  (when (nil? (time-coerce/from-string (str d)))
+    {:error :wrong-format :expected :date-time :data d}))
 
 (defn validate-hostname [d]
   (if (re-matches hostname-pattern (str d))

--- a/src/webjure/json_schema/validator/format.clj
+++ b/src/webjure/json_schema/validator/format.clj
@@ -1,0 +1,71 @@
+(ns webjure.json-schema.validator.format
+  (:require [clj-time.format :as time-format]))
+
+(def rfc3339-formatter (time-format/formatters :date-time))
+
+(def hostname-pattern
+  ;; Courtesy of StackOverflow http://stackoverflow.com/a/1420225
+  #"^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$")
+
+(def ipv4-pattern
+  #"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$")
+
+(def ipv6-pattern
+  #"^[:a-f0-9]+$")
+
+(def email-pattern
+  ;; I know, this isn't too permissive. This just checks
+  ;; that the email has an @ character (exactly one) and something
+  ;; on both sides of it.
+  #"^[^@]+@[^@]+$")
+
+(defn validate-date-time [d]
+  (try
+    (time-format/parse rfc3339-formatter (str d))
+    nil
+    (catch Exception e
+      {:error :wrong-format :expected :date-time :data d
+       :parse-exception e})))
+
+(defn validate-hostname [d]
+  (if (re-matches hostname-pattern (str d))
+    nil
+    {:error :wrong-format :expected :hostname :data d}))
+
+(defn validate-ipv4 [d]
+  (let [[ip & parts] (re-matches ipv4-pattern (str d))]
+    (if (and ip
+             (every? #(<= 0 (Integer/parseInt %) 255) parts))
+      nil
+      {:error :wrong-format :expected :ipv4 :data d})))
+
+;; Check that the string contains only the allowed characters
+;; and contains an ':' character. Then try to parse with Java
+;; Inet6Address class.
+(defn validate-ipv6 [d]
+  (let [d (str d)]
+    (if (and (re-matches ipv6-pattern d)
+             (.contains d ":")
+             (try
+               (java.net.Inet6Address/getByName d)
+               true
+               (catch Exception e#
+                 false)))
+      nil
+      {:error :wrong-format :expected :ipv6 :data d})))
+
+(defn validate-uri [d]
+  (let [d (str d)]
+    (if-not (and (.contains d "/")
+                 (try
+                   (java.net.URI. d)
+                   true
+                   (catch java.net.URISyntaxException e#
+                     false)))
+      {:error :wrong-format :expected :uri :data d}
+      nil)))
+
+(defn validate-email [d]
+  (if-not (re-matches email-pattern (str d))
+    {:error :wrong-format :expected :email :data d}
+    nil))

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -195,8 +195,7 @@
           props (gensym "PROPS")
           prop (gensym "PROP")
           extra-properties (gensym "EXTRA-PROPS")
-          invalid-pp (gensym "INVALID-PP")
-          _ (println "PATTERN PROPERTIES: " pattern-properties)]
+          invalid-pp (gensym "INVALID-PP")]
       `(if-not (map? ~data)
          ~(ok)
          (let [~property-errors

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -2,7 +2,8 @@
   "Macro version of validator. Loads and parses schema at compile time and
   emits code to check data for validity."
   (:require [clj-time.coerce :as time]
-            [webjure.json-schema.ref :refer [resolve-schema resolve-ref]]))
+            [webjure.json-schema.ref :refer [resolve-schema resolve-ref]]
+            [webjure.json-schema.validator.string :as string]))
 
 
 (declare validate)
@@ -122,13 +123,13 @@
               (ok)])
 
          ~@(when min
-             [`(< (count ~data) ~min)
+             [`(< (string/length ~data) ~min)
               `(let [~e {:error :string-too-short
                          :minimum-length ~min
                          :data ~data}]
                  ~(error e))])
          ~@(when max
-             [`(> (count ~data) ~max)
+             [`(> (string/length ~data) ~max)
               `(let [~e {:error :string-too-long
                          :maximum-length ~max
                          :data ~data}]

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -206,13 +206,15 @@
            ~(error e)))
 
       (= format "uri")
-      `(try
-         (java.net.URI. (str ~data))
-         ~(ok)
-         (catch java.net.URISyntaxException e#
-           (let [~e {:error :wrong-format :expected :uri :data ~data
-                     :parse-exception e#}]
-             ~(error e))))
+      `(if-not (and (.contains (str ~data) "/")
+                    (try
+                      (java.net.URI. (str ~data))
+                      true
+                      (catch java.net.URISyntaxException e#
+                        false)))
+         (let [~e {:error :wrong-format :expected :uri :data ~data}]
+           ~(error e))
+         ~(ok))
 
       ;; Warn about unsupported format (no validation will be done)
       (not (nil? format))

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -1,276 +1,379 @@
 (ns webjure.json-schema.validator.macro
   "Macro version of validator. Loads and parses schema at compile time and
   emits code to check data for validity."
-  (:require [clojure.java.io :as io]
-            [cheshire.core :as cheshire]
-            [clj-time.coerce :as time]))
+  (:require [clj-time.coerce :as time]
+            [webjure.json-schema.ref :refer [resolve-schema resolve-ref]]))
 
-(defn resolve-ref [uri]
-  (let [schema (io/file uri)]
-    (when (.canRead schema)
-      (cheshire/parse-string (slurp schema)))))
 
-(defmulti validate-by-type
-  "Create expansion code for JSON schema validation by type. The expansion takes the data
-  symbol, callbacks to create expansions for error and ok validations and the options map."
-  (fn [schema data-sym error ok options] (get schema "type")))
+(declare validate)
 
-(defn error [error-sym e]
-  `(conj ~error-sym ~e))
+;; Below are the functions that emit validations.
+;; They all have the same signature: they take a schema,
+;; the symbol for the data, error and ok expansion functions
+;; and the options map. They return nil if there is no check
+;; to be done for this type or an expansion for the check.
 
-(defn- resolve-schema [schema options]
-  (if-let [ref (get schema "$ref")]
-    (let [referenced-schema ((:ref-resolver options) ref)]
-      (if-not referenced-schema
-        ;; Throw compile time error if schema can't be loaded
-        (throw (IllegalArgumentException.
-                (str "Unable to resolve referenced schema: " ref)))
-        referenced-schema))
-    schema))
+(defn validate-type
+  "Check one of the seven JSON schema core types"
+  [{type "type"} data-sym error ok _]
 
-(declare validate-enum-value)
-(defn validate [{enum :enum :as schema} data error ok options]
-  (let [schema (resolve-schema schema options)
-        e (gensym "E")]
-    `(or ~(validate-enum-value schema data identity (constantly nil))
-         ~(validate-by-type schema data error ok options))))
+  (when type
+    (let [expand-type #(case %
+                         "array" `(sequential? ~data-sym)
+                         "boolean" `(instance? Boolean ~data-sym)
+                         "integer" `(or (instance? Integer ~data-sym)
+                                        (instance? Long ~data-sym)
+                                        (instance? java.math.BigInteger ~data-sym))
+                         "number" `(number? ~data-sym)
+                         "null" `(nil? ~data-sym)
+                         "object" `(map? ~data-sym)
+                         "string" `(string? ~data-sym)
+                         nil nil)
+          ]
+      (let [e (gensym "ERROR")]
+        `(if ~(if (sequential? type)
+                `(or ~@(map expand-type type))
+                (expand-type type))
+           ~(ok)
+           (let [~e {:error :wrong-type
+                     :expected ~(if (sequential? type)
+                                 (into #{}
+                                       (map keyword)
+                                       type)
+                                 (keyword type))
+                     :data ~data-sym}]
+             ~(error e)))))))
 
-(defmethod validate-by-type "object"
-  [{properties "properties"
-    :as        schema} data
-   error ok options]
-
-  (let [required (if (:draft3-required options)
-                   ;; Draft 3 required is an attribute of the property schema
-                   (into #{}
-                         (for [[property-name property-schema] properties
-                               :when (get property-schema "required")]
-                           property-name))
-
-                   ;; Draft 4 has separate required attribute with a list of property names
-                   (into #{}
-                         (get schema "required")))
-        property-names (into #{} (map first properties))
-        e (gensym "E")
-        property-errors (gensym "PROP-ERROR")
-        v (gensym "V")
-        d (gensym "DATA")]
-    `(if-not (map? ~data)
-       ~(error {:error :wrong-type :expected :map
-                :data  data})
-       (let [~property-errors
-             (as-> {} ~property-errors
-
-               ;; Check required props
-               ~@(for [p required]
-                   `(if (nil? (get ~data ~p))
-                      (assoc ~property-errors ~p {:error :missing-property})
-                      ~property-errors))
-
-               ;; Property validations
-               ~@(for [[property-name property-schema] properties
-                       :let [error (fn [error]
-                                     `(assoc ~property-errors ~property-name ~error))
-                             ok (constantly property-errors)]]
-                   `(let [~v (get ~data ~property-name)]
-                      (if (nil? ~v)
-                        ;; nil values for required fields are checked earlier
-                        ~property-errors
-
-                        ;; validate property by type
-                        ~(validate property-schema v
-                                   error ok options)))))]
-         (if-not (empty? ~property-errors)
-           (let [~e {:error      :properties
-                     :data       ~data
-                     :properties ~property-errors}]
-             ~(error e))
-
-           (let [property-names# ~property-names
-                 extra-properties# (into #{}
-                                         (keep #(when-not (property-names# %) %)
-                                               (keys ~data)))]
-             (if-not (empty? extra-properties#)
-               ;; We have properties outside the schema, error
-               ;; FIXME: check additionalProperties flag
-               (let [~e {:error          :additional-properties
-                         :property-names extra-properties#}]
-                 ~(error e))
-
-               ;; No errors
-               ~(ok))))))))
+(defn type-is?
+  "Check if a type validation is taking place. This can be used to
+  elide instance checks in later validations."
+  [{type "type"} & types]
+  (let [types (into #{} types)]
+    (and type
+         (not (sequential? type)) ;; either type, can't be sure
+         (types type))))
 
 (defn validate-number-bounds [{min           "minimum" max "maximum"
                                exclusive-min "exclusiveMinimum"
                                exclusive-max "exclusiveMaximum"
-                               multiple-of   "multipleOf"}
-                              data error ok]
+                               multiple-of   "multipleOf" :as schema}
+                              data error ok _]
+  (when (or min max multiple-of)
+    (let [e (gensym "E")]
+      `(cond
+         ;; If no type check has been done, add type check that
+         ;; skips non-number types
+         ~@(when-not (type-is? schema "integer" "number")
+             [`(not (number? ~data))
+              (ok)])
+
+         ~@(when (and min exclusive-min)
+             [`(<= ~data ~min)
+              `(let [~e {:error     :out-of-bounds
+                         :data      ~data
+                         :minimum   ~min
+                         :exclusive true}]
+                 ~(error e))])
+
+         ~@(when (and min (not exclusive-min))
+             [`(< ~data ~min)
+              `(let [~e {:error     :out-of-bounds
+                         :data      ~data
+                         :minimum   ~min
+                         :exclusive false}]
+                 ~(error e))])
+
+
+         ~@(when (and max exclusive-max)
+             [`(>= ~data ~max)
+              `(let [~e {:error     :out-of-bounds
+                         :data      ~data
+                         :maximum   ~max
+                         :exclusive true}]
+                 ~(error e))])
+
+         ~@(when (and max (not exclusive-max))
+             [`(> ~data ~max)
+              `(let [~e {:error     :out-of-bounds
+                         :data      ~data
+                         :maximum   ~max
+                         :exclusive false}]
+                 ~(error e))])
+
+         ~@(when multiple-of
+             [`(not (or (zero? ~data)
+                        (let [d# (/ ~data ~multiple-of)]
+                          (or (integer? d#)
+                              (= (Math/floor d#) d#)))))
+              `(let [~e {:error :not-multiple-of
+                         :data ~data
+                         :expected-multiple-of ~multiple-of}]
+                 ~(error e))])
+
+         :default
+         ~(ok)))))
+
+(defn validate-string-length [{min "minLength" max "maxLength" :as schema} data error ok _]
+  (when (or min max)
+    (let [e (gensym "E")]
+      `(cond
+         ~@(when-not (type-is? schema "string")
+             [`(not (string? ~data))
+              (ok)])
+
+         ~@(when min
+             [`(< (count ~data) ~min)
+              `(let [~e {:error :string-too-short
+                         :minimum-length ~min
+                         :data ~data}]
+                 ~(error e))])
+         ~@(when max
+             [`(> (count ~data) ~max)
+              `(let [~e {:error :string-too-long
+                         :maximum-length ~max
+                         :data ~data}]
+                 ~(error e))])
+
+         :default
+         ~(ok)))))
+
+(defn validate-string-pattern [{pattern "pattern"} data error ok _]
+  (when pattern
+    (let [e (gensym "E")]
+      `(if-not (string? ~data)
+         ~(ok)
+         (if (re-find ~(re-pattern pattern) ~data)
+           ~(ok)
+           (let [~e {:error :string-does-not-match-pattern
+                     :pattern ~pattern
+                     :data ~data}]
+             ~(error e)))))))
+
+(defn validate-string-format [{format "format"} data error ok _]
   (let [e (gensym "E")]
-    `(cond
-       ~@(when (and min exclusive-min)
-           [`(<= ~data ~min)
-            `(let [~e {:error     :out-of-bounds
-                       :data      ~data
-                       :minimum   ~min
-                       :exclusive true}]
-               ~(error e))])
-
-       ~@(when (and min (not exclusive-min))
-           [`(< ~data ~min)
-            `(let [~e {:error     :out-of-bounds
-                       :data      ~data
-                       :minimum   ~min
-                       :exclusive false}]
-               ~(error e))])
+    (cond
+      (= format "date-time")
+      `(if (nil? (time/from-string ~data))
+         (let [~e {:error :wrong-format :expected :date-time :data ~data}]
+           ~(error e))
+         ~(ok))
 
 
-       ~@(when (and max exclusive-max)
-           [`(>= ~data ~max)
-            `(let [~e {:error     :out-of-bounds
-                       :data      ~data
-                       :maximum   ~max
-                       :exclusive true}]
-               ~(error e))])
+      ;; Warn about unsupported format (no validation will be done)
+      (not (nil? format))
+      (do (println "Unsupported string format: " format)
+          nil)
 
-       ~@(when (and max (not exclusive-max))
-           [`(> ~data ~max)
-            `(let [~e {:error     :out-of-bounds
-                       :data      ~data
-                       :maximum   ~max
-                       :exclusive false}]
-               ~(error e))])
+      ;; No format in schema
+      :default
+      nil)))
 
-       ~@(when multiple-of
-           [`(not= 0 (rem ~data ~multiple-of))
-            `(let [~e {:error :not-multiple-of
-                       :data ~data
-                       :expected-multiple-of ~multiple-of}]
-               ~(error e))])
+(defn validate-properties [{properties "properties"
+                            pattern-properties "patternProperties"
+                            additional-properties "additionalProperties"
+                           :as        schema} data error ok options]
 
-       :default
-       ~(ok))))
+  (when (or properties additional-properties)
+    (let [properties (or properties {})
+          additional-properties (if (nil? additional-properties) {} additional-properties)
+          required (if (:draft3-required options)
+                     ;; Draft 3 required is an attribute of the property schema
+                     (into #{}
+                           (for [[property-name property-schema] properties
+                                 :when (get property-schema "required")]
+                             property-name))
 
-(defmethod validate-by-type "integer"
-  [schema data error ok _]
-  (let [e (gensym "E")]
-    `(if-not (integer? ~data)
-       (let [~e {:error :wrong-type :expected :integer :data ~data}]
-         ~(error e))
-       ~(validate-number-bounds schema data error ok))))
+                     ;; Draft 4 has separate required attribute with a list of property names
+                     (into #{}
+                           (get schema "required")))
+          property-names (into #{} (map first properties))
+          e (gensym "E")
+          property-errors (gensym "PROP-ERROR")
+          v (gensym "V")
+          d (gensym "DATA")
+          props (gensym "PROPS")
+          prop (gensym "PROP")
+          extra-properties (gensym "EXTRA-PROPS")
+          _ (println "PATTERN PROPERTIES: " pattern-properties)]
+      `(if-not (map? ~data)
+         ~(ok)
+         (let [~property-errors
+               (as-> {} ~property-errors
 
-(defmethod validate-by-type "number"
-  [schema data error ok _]
-  (let [e (gensym "E")]
-    `(if-not (number? ~data)
-       (let [~e {:error :wrong-type :expected :number :data ~data}]
-         ~(error e))
-       ~(validate-number-bounds schema data error ok))))
+                 ;; Check required props
+                 ~@(for [p required]
+                     `(if-not (contains? ~data ~p)
+                        (assoc ~property-errors ~p {:error :missing-property})
+                        ~property-errors))
+
+                 ;; Property validations
+                 ~@(for [[property-name property-schema] properties
+                         :let [error (fn [error]
+                                       `(assoc ~property-errors ~property-name ~error))
+                               ok (constantly property-errors)]]
+                     `(let [~v (get ~data ~property-name)]
+                        (if (nil? ~v)
+                          ;; nil values for required fields are checked earlier
+                          ~property-errors
+
+                          ;; validate property by type
+                          ~(validate property-schema v error ok options)))))]
+           (if-not (empty? ~property-errors)
+             (let [~e {:error      :properties
+                       :data       ~data
+                       :properties ~property-errors}]
+               ~(error e))
+
+             (let [~extra-properties ~(when-not (#{true {}} additional-properties)
+                                        `(as-> (keys ~data) ~props
+                                           (remove ~property-names ~props)
+                                           ~@(when pattern-properties
+                                               [`(remove
+                                                  (fn [p#]
+                                                    (some #(re-find % p#)
+                                                          [~@(map re-pattern
+                                                                  (keys pattern-properties))]))
+                                                  ~props)])
+                                           (into #{} ~props)))]
+               ~(cond
+                  ;; No additional properties allowed, signal error if there are any
+                  (false? additional-properties)
+                  `(if-not (empty? ~extra-properties)
+                     ;; We have properties outside the schema, error
+                     (let [~e {:error          :additional-properties
+                               :property-names ~extra-properties}]
+                       ~(error e))
+
+                     ;; No errors
+                     ~(ok))
+
+
+                  ;; Additional properties is a schema, check all extra properties
+                  ;; against schema
+                  (and (map? additional-properties) (not= {} additional-properties))
+                  `(let [invalid-additional-properties#
+                         (into {}
+                               (keep (fn [~prop]
+                                          (let [~v (get ~data ~prop)
+                                                e# ~(validate additional-properties v options)]
+                                            (when e#
+                                              [~prop e#]))))
+                               ~extra-properties)]
+                     (if-not (empty? invalid-additional-properties#)
+                       (let [~e {:error :invalid-additional-properties
+                                 :invalid-additional-properties invalid-additional-properties#
+                                 :data ~data}]
+                         ~(error e))
+                       ~(ok)))
+
+                  :default
+                  (ok)))))))))
 
 (defn validate-enum-value
-  [{enum "enum"} data error ok]
-  (let [e (gensym "E")]
-    (if-let [allowed-values (when enum
-                              (into #{} enum))]
+  [{enum "enum"} data error ok _]
+  (when-let [allowed-values (and enum (into #{} enum))]
+    (let [e (gensym "E")]
       `(if-not (~allowed-values ~data)
          (let [~e {:error          :invalid-enum-value
                    :data           ~data
                    :allowed-values ~allowed-values}]
            ~(error e))
-         ~(ok))
-      (ok))))
+         ~(ok)))))
 
-(defmethod validate-by-type "string"
-  [schema data error ok _]
-  (let [e (gensym "E")]
-    `(if-not (string? ~data)
-       (let [~e {:error :wrong-type :expected :string :data ~data}]
-         ~(error e))
-       ~(if-let [format (get schema "format")]
-          (cond
-            (= format "date-time")
-            `(if (nil? (time/from-string ~data))
-               (let [~e {:error :wrong-format :expected :date-time :data ~data}]
+(defn validate-array-items [{item-schema "items" :as schema} data error ok options]
+  (when item-schema
+    (let [e (gensym "E")
+          item (gensym "ITEM")
+          item-error (gensym "ITEM-ERROR")]
+      `(if-not (sequential? ~data)
+         ~(ok)
+         (loop [errors# []
+                i# 0
+                [~item & items#] ~data]
+           (if-not ~item
+             (if (empty? errors#)
+               ~(ok)
+               (let [~e {:error :array-items
+                         :data  ~data
+                         :items errors#}]
+                 ~(error e)))
+             (let [item-error#
+                   ~(if (and (map? item-schema) (item-schema "enum"))
+                      (validate-enum-value item-schema item
+                                           identity
+                                           (constantly nil)
+                                           options)
+                      (validate item-schema item options))]
+               (recur (if item-error#
+                        (conj errors# (assoc item-error#
+                                             :position i#))
+                        errors#)
+                      (inc i#)
+                      items#))))))))
+
+(defn validate-array-item-count [{min-items "minItems" max-items "maxItems"} data error ok options]
+  (when (or min-items max-items)
+    (let [e (gensym "E")
+          items (gensym "ITEMS")]
+      `(if-not (sequential? ~data)
+         ~(ok)
+         (let [~items (count ~data)]
+           (cond
+             ~@(when min-items
+                 [`(> ~min-items ~items)
+                  `(let [~e {:error :wrong-number-of-elements
+                             :minimum ~min-items :actual ~items}]
+                     ~(error e))])
+
+             ~@(when max-items
+                 [`(< ~max-items ~items)
+                  `(let [~e {:error :wrong-number-of-elements
+                             :maximum ~max-items :actual ~items}]
+                     ~(error e))])
+
+             :default
+             ~(ok)))))))
+
+(defn validate-array-unique-items [{unique-items "uniqueItems"} data error ok _]
+  (when unique-items
+    (let [item-count (gensym "IC")
+          e (gensym "E")]
+      `(if-not (sequential? ~data)
+         ~(ok)
+         (loop [seen# #{}
+                duplicates# #{}
+                [item# & items#] ~data]
+           (if-not item#
+             (if-not (empty? duplicates#)
+               (let [~e {:error :duplicate-items-not-allowed
+                         :duplicates duplicates#}]
                  ~(error e))
                ~(ok))
-
-            :default
-            (ok))
-          (ok)))))
-
-(defmethod validate-by-type "boolean"
-  [_ data error ok _]
-  (let [e (gensym "E")]
-    `(if (nil? (#{true false} ~data))
-       (let [~e  {:error :wrong-type :expected :boolean :data ~data}]
-         ~(error e))
-       ~(ok))))
-
-(defn validate-array-items [options item-schema data error ok]
-  (let [e (gensym "E")
-        item (gensym "ITEM")
-        item-error (gensym "ITEM-ERROR")]
-    `(loop [errors# []
-            i# 0
-            [~item & items#] ~data]
-       (if-not ~item
-         (if (empty? errors#)
-           ~(ok)
-           (let [~e {:error :array-items
-                     :data  ~data
-                     :items errors#}]
-             ~(error e)))
-         (let [item-error#
-               ~(if (and (map? item-schema) (item-schema "enum"))
-                  (validate-enum-value item-schema item
-                                       identity
-                                       (constantly nil))
-                  (validate item-schema item
-                            identity
-                            (constantly nil)
-                            options))]
-           (recur (if item-error#
-                    (conj errors# (assoc item-error#
-                                        :position i#))
-                    errors#)
-                  (inc i#)
-                  items#))))))
-
-(defmethod validate-by-type "array"
-  [{min-items "minItems" max-items "maxItems"
-    item-schema "items"
-    unique-items "uniqueItems"} data error ok options]
-  (let [e (gensym "E")
-        items (gensym "ITEMS")]
-    `(if-not (sequential? ~data)
-       (let [~e {:error :wrong-type :expected :array-like :data ~data}]
-         ~(error e))
-       (let [~items (count ~data)]
-         (cond
-           ~@(when min-items
-               [`(> ~min-items ~items)
-                `(let [~e {:error :wrong-number-of-elements
-                           :minimum ~min-items :actual ~items}]
-                   ~(error e))])
-
-           ~@(when max-items
-               [`(< ~max-items ~items)
-                `(let [~e {:error :wrong-number-of-elements
-                           :maximum ~max-items :actual ~items}]
-                   ~(error e))])
-
-           ~@(when unique-items
-               [`(not= ~items (count (into #{} ~data)))
-                `(let [~e {:error :duplicate-items-not-allowed}]
-                   ~(error e))])
-
-           :else ~(validate-array-items options item-schema data
-                                        error ok))))))
+             (recur (conj seen# item#)
+                    (if (seen# item#)
+                      (conj duplicates# item#)
+                      duplicates#)
+                    items#)))))))
 
 
-(defmethod validate-by-type :default
-  [schema data error ok _]
-  ;; If no type is specified, anything goes
-  (ok))
+
+(def validations [validate-type
+                  validate-enum-value
+                  validate-number-bounds
+                  validate-string-length validate-string-pattern validate-string-format
+                  validate-properties
+                  validate-array-items validate-array-item-count validate-array-unique-items])
+
+(defn validate
+  ([schema data options]
+   (validate schema data identity (constantly nil) options))
+  ([schema data error ok options]
+   (let [schema (resolve-schema schema options)
+         e (gensym "E")]
+     `(or ~@(for [validate-fn validations
+                  :let [form (validate-fn schema data error ok options)]
+                  :when form]
+              form)))))
 
 (defmacro make-validator
   "Create a validator function. The schema and options will be evaluated at compile time.
@@ -288,7 +391,4 @@
                         (eval options))
          data (gensym "DATA")]
      `(fn [~data]
-        ~(validate schema data
-                   identity
-                   (constantly nil)
-                   options)))))
+        ~(validate schema data options)))))

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -155,11 +155,14 @@
 
 
 
-(defn validate-string-format [{format "format"} data error ok _]
+(defn validate-string-format [{format "format"} data error ok
+                              {lax-date-time-format? :lax-date-time-format?}]
   (when format
     (let [e (gensym "E")]
       `(if-let [~e (~(case format
-                       "date-time" format/validate-date-time
+                       "date-time" (if lax-date-time-format?
+                                     format/validate-lax-date-time
+                                     format/validate-date-time)
                        "hostname" format/validate-hostname
                        "ipv4" format/validate-ipv4
                        "ipv6" format/validate-ipv6
@@ -554,7 +557,10 @@
                    Default just tries to read it as a file via slurp and parse.
 
   :draft3-required  when set to true, support draft3 style required (in property definition),
-                    defaults to false"
+                    defaults to false
+
+  :lax-date-time-format?  when set to true, allow more variation in date format,
+                          normally only strict RFC3339 dates are valid"
   ([schema options]
    (let [schema (eval schema)
          options (merge {:ref-resolver resolve-ref}

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -190,6 +190,9 @@
            (let [~e {:error :wrong-format :expected :ipv4 :data ~data}]
              ~(error e))))
 
+      ;; Check that the string contains only the allowed characters
+      ;; and contains an ':' character. Then try to parse with Java
+      ;; Inet6Address class.
       (= format "ipv6")
       `(if (and (re-matches ~ipv6-pattern ~data)
                 (.contains ~data ":")

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -164,6 +164,12 @@
 (def ipv6-pattern
   #"^[:a-f0-9]+$")
 
+(def email-pattern
+  ;; I know, this isn't too permissive. This just checks
+  ;; that the email has an @ character (exactly one) and something
+  ;; on both sides of it.
+  #"^[^@]+@[^@]+$")
+
 (defn validate-string-format [{format "format"} data error ok _]
   (let [e (gensym "E")]
     (cond
@@ -213,6 +219,12 @@
                       (catch java.net.URISyntaxException e#
                         false)))
          (let [~e {:error :wrong-format :expected :uri :data ~data}]
+           ~(error e))
+         ~(ok))
+
+      (= format "email")
+      `(if-not (re-matches ~email-pattern (str ~data))
+         (let [~e {:error :wrong-format :expected :email :data ~data}]
            ~(error e))
          ~(ok))
 

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -263,7 +263,10 @@
                           ~property-errors
 
                           ;; validate property by type
-                          ~(validate property-schema v error ok options))))
+                          (let [~e ~(validate property-schema v options)]
+                            (if ~e
+                              ~(error e)
+                              ~(ok))))))
 
                  ;; Validate pattern properties
                  ~@(for [[pattern schema] pattern-properties

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -153,6 +153,10 @@
 
 (def rfc3339-formatter (time-format/formatters :date-time))
 
+(def hostname-pattern
+  ;; Courtesy of StackOverflow http://stackoverflow.com/a/1420225
+  #"^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$")
+
 (defn validate-string-format [{format "format"} data error ok _]
   (let [e (gensym "E")]
     (cond
@@ -164,6 +168,12 @@
            (let [~e {:error :wrong-format :expected :date-time :data ~data
                      :parse-exception e#}]
              ~(error e))))
+
+      (= format "hostname")
+      `(if (re-matches ~hostname-pattern ~data)
+         ~(ok)
+         (let [~e {:error :wrong-format :expected :hostname :data ~data}]
+           ~(error e)))
 
 
       ;; Warn about unsupported format (no validation will be done)

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -161,13 +161,13 @@
     (let [e (gensym "E")]
       `(if-let [~e (~(case format
                        "date-time" (if lax-date-time-format?
-                                     format/validate-lax-date-time
-                                     format/validate-date-time)
-                       "hostname" format/validate-hostname
-                       "ipv4" format/validate-ipv4
-                       "ipv6" format/validate-ipv6
-                       "uri" format/validate-uri
-                       "email" format/validate-email
+                                     'webjure.json-schema.validator.format/validate-lax-date-time
+                                     'webjure.json-schema.validator.format/validate-date-time)
+                       "hostname" 'webjure.json-schema.validator.format/validate-hostname
+                       "ipv4" 'webjure.json-schema.validator.format/validate-ipv4
+                       "ipv6" 'webjure.json-schema.validator.format/validate-ipv6
+                       "uri" 'webjure.json-schema.validator.format/validate-uri
+                       "email" 'webjure.json-schema.validator.format/validate-email
                        (do
                          (println "WARNING: Unsupported format: " format)
                          `(constantly nil)))
@@ -537,12 +537,12 @@
   ([schema data options]
    (validate schema data identity (constantly nil) options))
   ([schema data error ok options]
-   (let [schema (resolve-schema schema options)
+   (let [options (assoc options
+                        :root-schema (or (:root-schema options)
+                                         (resolve-schema schema options)))
+         schema (resolve-schema schema options)
          e (gensym "E")
-         definitions (get schema "definitions")
-         options (assoc options
-                        :definitions (merge definitions
-                                            (:definitions options)))]
+         definitions (get schema "definitions")]
      `(or ~@(for [validate-fn validations
                   :let [form (validate-fn schema data error ok options)]
                   :when form]

--- a/src/webjure/json_schema/validator/macro.clj
+++ b/src/webjure/json_schema/validator/macro.clj
@@ -464,23 +464,26 @@
 (defn validate-array-unique-items [{unique-items "uniqueItems"} data error ok _]
   (when unique-items
     (let [item-count (gensym "IC")
-          e (gensym "E")]
+          e (gensym "E")
+          c (gensym "C")]
       `(if-not (sequential? ~data)
          ~(ok)
-         (loop [seen# #{}
-                duplicates# #{}
-                [item# & items#] ~data]
-           (if-not item#
-             (if-not (empty? duplicates#)
-               (let [~e {:error :duplicate-items-not-allowed
-                         :duplicates duplicates#}]
-                 ~(error e))
-               ~(ok))
-             (recur (conj seen# item#)
-                    (if (seen# item#)
-                      (conj duplicates# item#)
-                      duplicates#)
-                    items#)))))))
+         (let [~c (count ~data)]
+           (loop [seen# #{}
+                  duplicates# #{}
+                  i# 0]
+             (if (= i# ~c)
+               (if-not (empty? duplicates#)
+                 (let [~e {:error :duplicate-items-not-allowed
+                           :duplicates duplicates#}]
+                   ~(error e))
+                 ~(ok))
+               (let [item# (nth ~data i#)]
+                 (recur (conj seen# item#)
+                        (if (seen# item#)
+                          (conj duplicates# item#)
+                          duplicates#)
+                        (inc i#))))))))))
 
 (defn validate-not [{schema "not"} data error ok options]
   (when schema

--- a/src/webjure/json_schema/validator/string.clj
+++ b/src/webjure/json_schema/validator/string.clj
@@ -1,0 +1,12 @@
+(ns webjure.json-schema.validator.string)
+
+(defn length
+  "Calculate string length in unicode codepoints"
+  [str]
+  (let [string-length (count str)]
+    (loop [i 0
+           len 0]
+      (if (= i string-length)
+        len
+        (recur (+ i (Character/charCount (.codePointAt str i)))
+               (inc len))))))

--- a/test/webjure/json_schema/suite_test.clj
+++ b/test/webjure/json_schema/suite_test.clj
@@ -33,21 +33,20 @@
   (let [schema-sym (gensym "SCHEMA")]
     `(do
        ~@(for [[test-name tests] suite-tests]
-           (do (println "EXPANDING " test-name)
-               `(deftest ~(sym (str "suite-" test-name))
-                  ~@(for [{desc "description"
-                           schema "schema"
-                           tests "tests"} tests]
-                      `(testing ~desc
-                         (let [~schema-sym (validate-fn ~schema {})]
-                           ~@(for [{desc "description"
-                                    data "data"
-                                    valid? "valid"} tests]
-                               (if valid?
-                                 `(is (nil? (~schema-sym ~data))
-                                      ~(str "Test '" desc "' should be valid"))
-                                 `(is (~schema-sym ~data)
-                                      ~(str "Test '" desc "' should NOT be valid")))))))))))))
+           `(deftest ~(sym (str "suite-" test-name))
+              ~@(for [{desc "description"
+                       schema "schema"
+                       tests "tests"} tests]
+                  `(testing ~desc
+                     (let [~schema-sym (validate-fn ~schema {})]
+                       ~@(for [{desc "description"
+                                data "data"
+                                valid? "valid"} tests]
+                           (if valid?
+                             `(is (nil? (~schema-sym ~data))
+                                  ~(str "Test '" desc "' should be valid"))
+                             `(is (~schema-sym ~data)
+                                  ~(str "Test '" desc "' should NOT be valid"))))))))))))
 
 
 (define-suite-tests)

--- a/test/webjure/json_schema/suite_test.clj
+++ b/test/webjure/json_schema/suite_test.clj
@@ -12,6 +12,8 @@
                       "definitions.json"
 
                       ;; FIXME: create a resolver for these
+                      ;; the normal refs mostly work, but large linked
+                      ;; schema causes problems with the macros
                       "refRemote.json"
                       "ref.json"
                       })

--- a/test/webjure/json_schema/suite_test.clj
+++ b/test/webjure/json_schema/suite_test.clj
@@ -1,0 +1,63 @@
+(ns webjure.json-schema.suite-test
+  "Tests for https://github.com/json-schema-org/JSON-Schema-Test-Suite.
+  The test suite is added as a submodule under test/resources."
+  (:require  [clojure.test :as t :refer [deftest is testing]]
+             [webjure.json-schema.test-util :refer [validate-fn]]
+             [clojure.java.io :as io]
+             [cheshire.core :as cheshire]
+             [clojure.string :as str]))
+
+(def excluded-files #{;; creating a validator fails for an invalid definition
+                      ;; test this separately
+                      "definitions.json"
+
+                      ;; FIXME: create a resolver for these
+                      "refRemote.json"
+                      "ref.json"
+                      })
+
+(def suite-tests
+  (->> (io/file "test/resources/JSON-Schema-Test-Suite/tests/draft4")
+       file-seq
+       (filter #(.endsWith (.getName %) ".json"))
+       (filter #(not (excluded-files (.getName %))))
+       (mapv (juxt #(let [n (.getName %)]
+                      (subs n 0 (- (count n) 5)))
+                   #(cheshire/parse-string (slurp %))))
+       (into {})))
+
+(defn sym [name]
+  (symbol (str/replace name " " "-")))
+
+(defmacro define-suite-tests []
+  (let [schema-sym (gensym "SCHEMA")]
+    `(do
+       ~@(for [[test-name tests] suite-tests]
+           (do (println "EXPANDING " test-name)
+               `(deftest ~(sym (str "suite-" test-name))
+                  ~@(for [{desc "description"
+                           schema "schema"
+                           tests "tests"} tests]
+                      `(testing ~desc
+                         (let [~schema-sym (validate-fn ~schema {})]
+                           ~@(for [{desc "description"
+                                    data "data"
+                                    valid? "valid"} tests]
+                               (if valid?
+                                 `(is (nil? (~schema-sym ~data))
+                                      ~(str "Test '" desc "' should be valid"))
+                                 `(is (~schema-sym ~data)
+                                      ~(str "Test '" desc "' should NOT be valid")))))))))))))
+
+;; 275 asserts => 82 fails
+;; 273 asserta => 78 fails
+;; => 76
+;; => 74
+;; => 72
+;; => 70
+;; => 67
+;; => 64
+;; => 63
+;; 61, 60, 57
+
+(define-suite-tests)

--- a/test/webjure/json_schema/suite_test.clj
+++ b/test/webjure/json_schema/suite_test.clj
@@ -49,15 +49,5 @@
                                  `(is (~schema-sym ~data)
                                       ~(str "Test '" desc "' should NOT be valid")))))))))))))
 
-;; 275 asserts => 82 fails
-;; 273 asserta => 78 fails
-;; => 76
-;; => 74
-;; => 72
-;; => 70
-;; => 67
-;; => 64
-;; => 63
-;; 61, 60, 57
 
 (define-suite-tests)

--- a/test/webjure/json_schema/test_util.clj
+++ b/test/webjure/json_schema/test_util.clj
@@ -19,12 +19,13 @@
                  (p schema)
                  schema)
         opts (or (first opts) {})]
-    `(fn [data#]
-       (let [fn-res# (validate ~schema data# ~opts)
-             macro-res# ((make-validator ~schema ~opts) data#)]
-         (is (= fn-res# macro-res#)
-             "function and macro versions validate in the same way")
-         macro-res#))))
+    `(let [macro-validator# (make-validator ~schema ~opts)]
+       (fn [data#]
+         (let [fn-res# (validate ~schema data# ~opts)
+               macro-res# (macro-validator# data#)]
+           (is (= fn-res# macro-res#)
+               "function and macro versions validate in the same way")
+           fn-res#)))))
 
 (defmacro defvalidate [name schema & opts]
   (let [schema (if (string? schema)

--- a/test/webjure/json_schema/test_util.clj
+++ b/test/webjure/json_schema/test_util.clj
@@ -20,17 +20,11 @@
                  schema)
         opts (or (first opts) {})]
     `(fn [data#]
-       (try
-         (let [;;fn-res# (validate ~schema data# ~opts)
-               macro-res# ((make-validator ~schema ~opts) data#)]
-           #_(is (= fn-res# macro-res#)
-                 "function and macro versions validate in the same way")
-           macro-res#)
-         (catch Throwable t#
-           (is false (str "Validation exception."
-                          "\nSchema: " ~(pr-str schema)
-                          "\nData: " (pr-str data#)
-                          "\nMessage: " (.getMessage t#))))))))
+       (let [fn-res# (validate ~schema data# ~opts)
+             macro-res# ((make-validator ~schema ~opts) data#)]
+         (is (= fn-res# macro-res#)
+             "function and macro versions validate in the same way")
+         macro-res#))))
 
 (defmacro defvalidate [name schema & opts]
   (let [schema (if (string? schema)

--- a/test/webjure/json_schema/test_util.clj
+++ b/test/webjure/json_schema/test_util.clj
@@ -1,0 +1,45 @@
+(ns webjure.json-schema.test-util
+  (:require [clojure.test :as t :refer [is]]
+            [webjure.json-schema.validator :refer [validate]]
+            [webjure.json-schema.validator.macro :refer [make-validator]]
+            [cheshire.core :as cheshire]))
+
+(defn p [resource-path]
+  (->> resource-path
+       (str "test/resources/")
+       slurp cheshire/parse-string))
+
+;; Define a macro that defines a new validator function.
+;; The function calls both the function style validation and
+;; the generated macro version and verifies that they validate
+;; errors in the same way.
+
+(defmacro validate-fn [schema & opts]
+  (let [schema (if (string? schema)
+                 (p schema)
+                 schema)
+        opts (or (first opts) {})]
+    `(fn [data#]
+       (try
+         (let [;;fn-res# (validate ~schema data# ~opts)
+               macro-res# ((make-validator ~schema ~opts) data#)]
+           #_(is (= fn-res# macro-res#)
+                 "function and macro versions validate in the same way")
+           macro-res#)
+         (catch Throwable t#
+           (is false (str "Validation exception."
+                          "\nSchema: " ~(pr-str schema)
+                          "\nData: " (pr-str data#)
+                          "\nMessage: " (.getMessage t#))))))))
+
+(defmacro defvalidate [name schema & opts]
+  (let [schema (if (string? schema)
+                 (p schema)
+                 schema)
+        opts (or (first opts) {})]
+    `(defn ~name [data#]
+       (let [fn-res# (validate ~schema data# ~opts)
+             macro-res# ((make-validator ~schema ~opts) data#)]
+         (is (= fn-res# macro-res#)
+             "function and macro versions validate in the same way")
+         fn-res#))))

--- a/test/webjure/json_schema/validator_test.clj
+++ b/test/webjure/json_schema/validator_test.clj
@@ -1,52 +1,28 @@
 (ns webjure.json-schema.validator-test
-  (:require [clojure.test :refer [deftest testing is]]
-            [webjure.json-schema.validator :refer [validate]]
-            [webjure.json-schema.validator.macro :refer [make-validator]]
-            [cheshire.core :as cheshire]))
-
-
-(defn p [resource-path]
-  (->> resource-path
-       (str "test/resources/")
-       slurp cheshire/parse-string))
-
-;; Define a macro that defines a new validator function.
-;; The function calls both the function style validation and
-;; the generated macro version and verifies that they validate
-;; errors in the same way.
-(defmacro defvalidate [name schema & opts]
-  (let [schema (if (string? schema)
-                 (p schema)
-                 schema)
-        opts (or (first opts) {})]
-    `(defn ~name [data#]
-       (let [fn-res# (validate ~schema data# ~opts)
-             macro-res# ((make-validator ~schema ~opts) data#)]
-         (is (= fn-res# macro-res#)
-             "function and macro versions validate in the same way")
-         fn-res#))))
+  (:require [cheshire.core :as cheshire]
+            [clojure.test :refer [deftest is testing]]
+            [webjure.json-schema.test-util :refer [defvalidate p]]))
 
 (defvalidate address-and-phone "address-and-phone.schema.json")
 
 (deftest validate-address-and-phone
   (testing "jsonschema.net example schema"
-    (let [s (p "address-and-phone.schema.json")]
-      (testing "valid json returns nil errors"
-        (is (nil? (address-and-phone (p "address-and-phone-valid.json")))))
+    (testing "valid json returns nil errors"
+      (is (nil? (address-and-phone (p "address-and-phone-valid.json")))))
 
-      (testing "missing property error is reported"
-        (let [e (address-and-phone (p "address-and-phone-city-and-code-missing.json"))]
-          (is (= :properties (:error e)))
-          ;; "city" is reported as missing because it is required
-          (is (= :missing-property (get-in e [:properties "address" :properties "city" :error])))
+    (testing "missing property error is reported"
+      (let [e (address-and-phone (p "address-and-phone-city-and-code-missing.json"))]
+        (is (= :properties (:error e)))
+        ;; "city" is reported as missing because it is required
+        (is (= :missing-property (get-in e [:properties "address" :properties "city" :error])))
 
-          ;; no errors in "phoneNumber" because missing "code" in first item is not required
-          (is (nil? (get-in e [:properties "phoneNumber"])))))
+        ;; no errors in "phoneNumber" because missing "code" in first item is not required
+        (is (nil? (get-in e [:properties "phoneNumber"])))))
 
-      (testing "additional properties are reported"
-        (is (= {:error          :additional-properties
-                :property-names #{"youDidntExpectMe" "orMe"}}
-               (address-and-phone (p "address-and-phone-additional-properties.json"))))))))
+    (testing "additional properties are reported"
+      (is (= {:error          :additional-properties
+              :property-names #{"youDidntExpectMe" "orMe"}}
+             (address-and-phone (p "address-and-phone-additional-properties.json")))))))
 
 (defvalidate ref-schema "person.schema.json")
 (deftest validate-referenced-schema
@@ -121,13 +97,13 @@
           :properties {"name" {:error :missing-property}}}
          (draft3-requires (cheshire/parse-string "{\"age\": 42}")))))
 
-(defvalidate num {"type" "number"})
+(defvalidate numb {"type" "number"})
 (deftest validate-number
-  (is (nil? (num 3.33)))
+  (is (nil? (numb 3.33)))
   (is (= {:error    :wrong-type
           :expected :number
           :data     "foo"}
-         (num "foo"))))
+         (numb "foo"))))
 
 (defvalidate valid-array {"type" "object"
                           "properties" {"things" {"type" "array"

--- a/test/webjure/json_schema/validator_test.clj
+++ b/test/webjure/json_schema/validator_test.clj
@@ -189,3 +189,26 @@
   (is (nil? (multiple-of-8 16)))
   (is (nil? (multiple-of-8 256)))
   (is (multiple-of-8 55)))
+
+;; Definition example from validation spec
+(defvalidate definitions (cheshire/parse-string "{
+    \"type\": \"array\",
+    \"items\": { \"$ref\": \"#/definitions/positiveInteger\" },
+    \"definitions\": {
+        \"positiveInteger\": {
+            \"type\": \"integer\",
+            \"minimum\": 0,
+            \"exclusiveMinimum\": true
+        }
+    }
+}"))
+
+(deftest validate-definitions
+  (is (nil? (definitions [1 2 3])))
+  (is (= {:error :array-items
+          :items [{:exclude true :minimum 0
+                   :error :out-of-bounds
+                   :data -2
+                   :position 1}]
+          :data [1 -2 3]}
+         (definitions [1 -2 3]))))


### PR DESCRIPTION
The old naive approach used "type" rules to dispatch on. The new mode has each validation as a separate rule.

Also added a macro version that expands schema validation function at compile time.

Added test suite to validate against.
